### PR TITLE
np to list, change the way of finding lines

### DIFF
--- a/solutions/project3(curves detector)/lines.py
+++ b/solutions/project3(curves detector)/lines.py
@@ -84,21 +84,6 @@ class Lines:
                 line_list.remove(lineOne)  # 길이가 3픽셀도 안되는 선은 세로선이거나 잡음이므로 지움.
         self.line_list = line_list
 
-    def temp_fucntion(self, img_param, image_name):
-        directory_path = "C:/Users/think/workspace/palm-beesly/test_img"
-        copied_img = copy.deepcopy(img_param)
-        height, width = copied_img.shape[:2]
-        for_showing = np.zeros((height, width, 1), dtype=np.uint8)
-        count = 0
-
-        for lineOne in self.line_list:
-            for point in lineOne.all_point_list:
-                x, y = point
-                for_showing[y][x] = 255
-            cv2.imwrite(os.path.join(directory_path, f"{image_name}{count}.png"), for_showing)
-            for_showing = for_showing * 0
-            count += 1
-
     def visualize_lines(self, img_param, color=False):
         copied_img = copy.deepcopy(img_param)
         height, width = copied_img.shape[:2]

--- a/solutions/project3(curves detector)/lines.py
+++ b/solutions/project3(curves detector)/lines.py
@@ -26,19 +26,6 @@ class Lines:
                 index_list.append(idx)
         return index_list
 
-    def set_line_info(self, point, max_distance):
-        find = False
-        for line in self.line_list:
-            if line.is_continuable(point, max_distance) is True:
-                find = True
-                line.add_point(point)
-        if find is False:
-            line = LineOne(self.number_of_front_points_to_find_slope)
-            self.line_list.append(line)
-            line.add_point(point)
-
-        return find
-
     def handle_point(self, point, max_distance):
         list_of_index_of_close_lines = self.get_index_list_of_close_lines(point, max_distance)
         number_of_close_lines = len(list_of_index_of_close_lines)

--- a/solutions/project3(curves detector)/main.py
+++ b/solutions/project3(curves detector)/main.py
@@ -72,10 +72,7 @@ def find_one_orientation_lines(img_param, min_grayscale, max_grayscale, max_line
         second_for_loop_max = w
 
     lines = Lines()
-    min_j_gap = 3
     for i in range(first_for_loop_max):
-        find = False
-        prev_j = 0
         for j in range(second_for_loop_max):
             if is_horizontal:
                 x = i
@@ -84,14 +81,9 @@ def find_one_orientation_lines(img_param, min_grayscale, max_grayscale, max_line
                 x = j
                 y = i
 
-            if img_param[y][x] > min_grayscale < max_grayscale and find is False:
-                find = True
+            if img_param[y][x] > min_grayscale < max_grayscale:
                 lines.handle_point([x, y], max_line_distance)
-                prev_j = j
-            elif (min_grayscale >= img_param[y][x] or img_param[y][x] >= max_grayscale) and find is True:
-                find = False
-                if j - prev_j > min_j_gap:
-                    lines.handle_point([x, y], max_line_distance)
+
         if is_horizontal:
             x = i
             y = 0
@@ -131,7 +123,8 @@ def main(img_param, min_grayscale, max_grayscale, min_line_length, max_line_dist
     vertical_lines = find_vertical_lines(copied, min_grayscale, max_grayscale, max_line_distance)
     stop = timeit.default_timer()
     print(round(stop - start, 6))
-    # # Filtering part
+
+    # Filtering part
     # horizontal_lines.filter_by_line_length(min_line_length)
     # vertical_lines.filter_by_line_length(min_line_length)
 
@@ -139,27 +132,34 @@ def main(img_param, min_grayscale, max_grayscale, min_line_length, max_line_dist
     horizontal_lines.leave_long_lines(number_of_lines_to_leave=number_of_lines_to_leave)
     vertical_lines.leave_long_lines(number_of_lines_to_leave=number_of_lines_to_leave)
 
-    # Visualizing part1
-    hori_before_flattening = horizontal_lines.visualize_lines(horizontal_img, color=True)
-    vert_before_flattening = vertical_lines.visualize_lines(vertical_img, color=True)
-
-    cv2.imshow("hori_before_flattening", hori_before_flattening)
-    cv2.imshow("vert_before_flattening", vert_before_flattening)
+    # cv2.imshow("hori_before_flattening", hori_before_flattening)
+    # cv2.imshow("vert_before_flattening", vert_before_flattening)
 
     # Flattening part
-    horizontal_lines.flatten(flattening_distance, is_horizontal=True)
-    vertical_lines.flatten(flattening_distance, is_horizontal=True)
+    # horizontal_lines.flatten(flattening_distance, is_horizontal=True)
+    # vertical_lines.flatten(flattening_distance, is_horizontal=True)
 
-    # Visualizing part2
+    # Visualizing part
     horizontal_img = horizontal_lines.visualize_lines(horizontal_img, color=True)
     vertical_img = horizontal_lines.visualize_lines(vertical_img, color=True)
 
+    cv2.imshow("hori before thinning", horizontal_img)
+    cv2.imshow("vert before thinning", vertical_img)
+
+    hori_gray = cv2.cvtColor(horizontal_img, cv2.COLOR_BGR2GRAY)
+    _, hori_thresh = cv2.threshold(hori_gray, 1, 255, cv2.THRESH_BINARY)
+    thinned_hori = cv2.ximgproc.thinning(hori_thresh)
+
+    vert_gray = cv2.cvtColor(vertical_img, cv2.COLOR_BGR2GRAY)
+    _, vert_thresh = cv2.threshold(vert_gray, 1, 255, cv2.THRESH_BINARY)
+    thinned_vert = cv2.ximgproc.thinning(vert_thresh)
+
     if both:
-        return horizontal_img, vertical_img
+        return thinned_hori, thinned_vert
     elif is_horizontal:
-        return horizontal_img
+        return thinned_hori
     else:
-        return vertical_img
+        return thinned_vert
 
 
 if __name__ == "__main__":
@@ -181,15 +181,18 @@ if __name__ == "__main__":
     number_of_lines_to_leave = 10  # Default value is 10
     flattening_distance = 4  # Default value is 4
 
-    main(img,
-         min_grayscale,
-         max_grayscale,
-         min_line_length,
-         max_line_distance,
-         number_of_lines_to_leave,
-         flattening_distance)
+    hori, vert = main(img,
+                      min_grayscale,
+                      max_grayscale,
+                      min_line_length,
+                      max_line_distance,
+                      number_of_lines_to_leave,
+                      flattening_distance)
 
     cv2.imshow("original", img)
+
+    cv2.imshow("hori", hori)
+    cv2.imshow("vert", vert)
 
     print("Done")
 

--- a/solutions/project3(curves detector)/main.py
+++ b/solutions/project3(curves detector)/main.py
@@ -2,7 +2,7 @@ import cv2
 import copy
 from lines import Lines
 import numpy as np
-import trackbar
+import timeit
 
 
 # 인풋으로 받은 캐니처리만 된 이미지에서 좌, 우, 위, 아래로 grayscle값이
@@ -122,13 +122,15 @@ def main(img_param, min_grayscale, max_grayscale, min_line_length, max_line_dist
          number_of_lines_to_leave, flattening_distance, both=True, is_horizontal=True):
     copied = copy.deepcopy(img_param)
     height, width = copied.shape[:2]
+    horizontal_img = np.zeros((height, width, 1), dtype=np.uint8)
+    vertical_img = np.zeros((height, width, 1), dtype=np.uint8)
 
     # Finding lines part
-    horizontal_img = np.zeros((height, width, 1), dtype=np.uint8)
+    start = timeit.default_timer()
     horizontal_lines = find_horizontal_lines(copied, min_grayscale, max_grayscale, max_line_distance)
-    vertical_img = np.zeros((height, width, 1), dtype=np.uint8)
     vertical_lines = find_vertical_lines(copied, min_grayscale, max_grayscale, max_line_distance)
-
+    stop = timeit.default_timer()
+    print(round(stop - start, 6))
     # # Filtering part
     # horizontal_lines.filter_by_line_length(min_line_length)
     # vertical_lines.filter_by_line_length(min_line_length)
@@ -179,59 +181,15 @@ if __name__ == "__main__":
     number_of_lines_to_leave = 10  # Default value is 10
     flattening_distance = 4  # Default value is 4
 
-    horizontal_img, vertical_img = main(img,
-                                        min_grayscale,
-                                        max_grayscale,
-                                        min_line_length,
-                                        max_line_distance,
-                                        number_of_lines_to_leave,
-                                        flattening_distance)
-
-    simplified_get_horizontal = lambda min_grayscale, \
-                                       max_grayscale, \
-                                       max_line_distance, \
-                                       flattening_distance: main(img,
-                                                                 min_grayscale,
-                                                                 max_grayscale,
-                                                                 min_line_length,
-                                                                 max_line_distance,
-                                                                 number_of_lines_to_leave,
-                                                                 flattening_distance,
-                                                                 both=False,
-                                                                 is_horizontal=True)
-
-    simplified_get_vertical = lambda min_grayscale, \
-                                     max_grayscale, \
-                                     max_line_distance, \
-                                     flattening_distance: main(img, min_grayscale,
-                                                               max_grayscale,
-                                                               min_line_length,
-                                                               max_line_distance,
-                                                               number_of_lines_to_leave,
-                                                               flattening_distance,
-                                                               both=False, is_horizontal=False)
+    main(img,
+         min_grayscale,
+         max_grayscale,
+         min_line_length,
+         max_line_distance,
+         number_of_lines_to_leave,
+         flattening_distance)
 
     cv2.imshow("original", img)
-    cv2.imshow("horizontal", horizontal_img)
-    cv2.imshow("vertical", vertical_img)
-
-    on_min_gray_changed_hori = lambda track_val: trackbar.on_min_gray_changed(track_val,
-                                                                              'horizontal',
-                                                                              simplified_get_horizontal)
-    on_max_gray_changed_hori = lambda track_val: trackbar.on_max_gray_changed(track_val,
-                                                                              'horizontal',
-                                                                              simplified_get_horizontal)
-    on_line_distance_changed_hori = lambda track_val: trackbar.on_line_distance_changed(track_val,
-                                                                                        'horizontal',
-                                                                                        simplified_get_horizontal)
-    on_flattening_distance_changed_hori = lambda track_val: trackbar.on_flattening_distance_changed(track_val,
-                                                                                                    'horizontal',
-                                                                                                    simplified_get_horizontal)
-
-    cv2.createTrackbar('min_gray', 'horizontal', min_grayscale, 255, on_min_gray_changed_hori)
-    cv2.createTrackbar('max_gray', 'horizontal', max_grayscale, 255, on_max_gray_changed_hori)
-    cv2.createTrackbar('line_distance', 'horizontal', max_line_distance, 30, on_line_distance_changed_hori)
-    cv2.createTrackbar('flattening', 'horizontal', flattening_distance, 15, on_flattening_distance_changed_hori)
 
     print("Done")
 


### PR DESCRIPTION
I've almost lists to np arrays in branch playground and speed was much slower. So in this PR, I rechanged np arrays to lists.
Also I changed the way of finding lines, which means that the previous way was that:
1. find lines as sets of point of contour.
2. flatten those lines by flatten function that I made.
3. result sucks.
And now:
1. find lines as sets of point of faces.
2. threshold it.
3. flatten the thresholded lines by cv2 built-in thinning function which is AWESOME so that I get the LINES.
4. execute a previous finding lines function which get sets of point of contour on thinned lines(This part is not currently featured.).